### PR TITLE
Postgresql restart changes

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -148,7 +148,7 @@
     group: "{{ postgresql_service_group }}"
     mode: u=rwX,g=rwXs,o=rx
 
-- name: PostgreSQL | Restart PostgreSQL
+- name: PostgreSQL | Reload PostgreSQL
   service:
     name: "{{ postgresql_service_name }}"
     state: reloaded

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -151,5 +151,5 @@
 - name: PostgreSQL | Restart PostgreSQL
   service:
     name: "{{ postgresql_service_name }}"
-    state: restarted
+    state: reloaded
   when: postgresql_configuration_pt1.changed or postgresql_configuration_pt2.changed or postgresql_configuration_pt3.changed or postgresql_systemd_custom_conf.changed


### PR DESCRIPTION
Changed to "reloaded" to avoid restart of the postgresql server
