### PR TITLE
Add initial recovery.conf management suport

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,8 @@ postgresql_service_group: "{{ postgresql_admin_user }}"
 postgresql_cluster_name: "main"
 postgresql_cluster_reset: false
 
+postgresql_install_recovery_conf: false
+
 postgresql_database_owner: "{{ postgresql_admin_user }}"
 # Extensions
 postgresql_ext_install_contrib: no
@@ -641,6 +643,26 @@ postgresql_exit_on_error: off
 # Reinitialize after backend crash?
 postgresql_restart_after_crash: on
 
+# recovery.conf
+
+postgresql_restore_command:
+postgresql_archive_cleanup_command:
+postgresql_recovery_end_command:
+
+postgresql_recovery_target_name:
+postgresql_recovery_target_time:
+postgresql_recovery_target_xid:
+
+postgresql_recovery_target_inclusive:
+postgresql_recovery_target:
+postgresql_recovery_target_timeline:
+postgresql_pause_at_recovery_target:    # <= 9.4
+postgresql_recovery_target_action:      # >= 9.5
+postgresql_standby_mode:
+postgresql_primary_conninfo:
+postgresql_primary_slot_name:
+postgresql_trigger_file:
+postgresql_recovery_min_apply_delay:
 
 #------------------------------------------------------------------------------
 # PGTUNE

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -118,6 +118,23 @@
   register: postgresql_configuration_pt3
   changed_when: "'_OK_' not in postgresql_configuration_pt3.stdout"
 
+- name: PostgreSQL | Place recovery.conf file
+  template:
+    src: "recovery.conf-{{postgresql_version}}.j2"
+    dest: "{{postgresql_data_directory}}/recovery.conf"
+    owner: "{{postgresql_service_user}}"
+    group: "{{postgresql_service_group}}"
+    mode: 0640
+  when: postgresql_install_recovery_conf
+  register: postgresql_configuration_recovery
+
+- name: PostgreSQL | Place recovery.conf symlink to /etc
+  file:
+    src: "{{postgresql_data_directory}}/recovery.conf"
+    dest: "{{postgresql_conf_directory}}/recovery.conf"
+    state: link
+  when: postgresql_install_recovery_conf
+
 - name: PostgreSQL | Create folder for additional configuration files
   file:
     name: "{{postgresql_conf_directory}}/conf.d"
@@ -153,3 +170,9 @@
     name: "{{ postgresql_service_name }}"
     state: reloaded
   when: postgresql_configuration_pt1.changed or postgresql_configuration_pt2.changed or postgresql_configuration_pt3.changed or postgresql_systemd_custom_conf.changed
+
+- name: PostgreSQL | Restart PostgreSQL for recovery
+  service:
+    name: "{{ postgresql_service_name }}"
+    state: restarted
+  when: postgresql_configuration_recovery.changed

--- a/templates/recovery.conf-9.4.j2
+++ b/templates/recovery.conf-9.4.j2
@@ -1,0 +1,213 @@
+# -------------------------------
+# PostgreSQL recovery config file
+# -------------------------------
+#
+# Edit this file to provide the parameters that PostgreSQL needs to
+# perform an archive recovery of a database, or to act as a replication
+# standby.
+#
+# If "recovery.conf" is present in the PostgreSQL data directory, it is
+# read on postmaster startup.  After successful recovery, it is renamed
+# to "recovery.done" to ensure that we do not accidentally re-enter
+# archive recovery or standby mode.
+#
+# This file consists of lines of the form:
+#
+#   name = value
+#
+# Comments are introduced with '#'.
+#
+# The complete list of option names and allowed values can be found
+# in the PostgreSQL documentation.
+#
+#---------------------------------------------------------------------------
+# ARCHIVE RECOVERY PARAMETERS
+#---------------------------------------------------------------------------
+#
+# restore_command
+#
+# specifies the shell command that is executed to copy log files
+# back from archival storage.  The command string may contain %f,
+# which is replaced by the name of the desired log file, and %p,
+# which is replaced by the absolute path to copy the log file to.
+#
+# This parameter is *required* for an archive recovery, but optional
+# for streaming replication.
+#
+# It is important that the command return nonzero exit status on failure.
+# The command *will* be asked for log files that are not present in the
+# archive; it must return nonzero when so asked.
+#
+# NOTE that the basename of %p will be different from %f; do not
+# expect them to be interchangeable.
+#
+{% if postgresql_restore_command %}
+restore_command = '{{postgresql_restore_command}}'		# e.g. 'cp /mnt/server/archivedir/%f %p'
+{% else %}
+#restore_command = ''		# e.g. 'cp /mnt/server/archivedir/%f %p'
+{% endif %}
+#
+#
+# archive_cleanup_command
+#
+# specifies an optional shell command to execute at every restartpoint.
+# This can be useful for cleaning up the archive of a standby server.
+#
+{% if postgresql_archive_cleanup_command %}
+archive_cleanup_command = '{{postgresql_archive_cleanup_command}}'
+{% else %}
+#archive_cleanup_command = ''
+{% endif %}
+#
+# recovery_end_command
+#
+# specifies an optional shell command to execute at completion of recovery.
+# This can be useful for cleaning up after the restore_command.
+#
+{% if postgresql_recovery_end_command %}
+recovery_end_command = '{{postgresql_recovery_end_command}}'
+{% else %}
+#recovery_end_command = ''
+{% endif %}
+#
+#---------------------------------------------------------------------------
+# RECOVERY TARGET PARAMETERS
+#---------------------------------------------------------------------------
+#
+# By default, recovery will rollforward to the end of the WAL log.
+# If you want to stop rollforward at a specific point, you
+# must set a recovery target.
+#
+# You may set a recovery target either by transactionId, by name,
+# or by timestamp. Recovery may either include or exclude the
+# transaction(s) with the recovery target value (ie, stop either
+# just after or just before the given target, respectively).
+#
+#
+{% if postgresql_recovery_target_name %}
+recovery_target_name = '{{postgresql_recovery_target_name}}'	# e.g. 'daily backup 2011-01-26'
+{% else %}
+#recovery_target_name = ''	# e.g. 'daily backup 2011-01-26'
+{% endif %}
+#
+{% if postgresql_recovery_target_time %}
+recovery_target_time = '{{postgresql_recovery_target_time}}'	# e.g. '2004-07-14 22:39:00 EST'
+{% else %}
+#recovery_target_time = ''	# e.g. '2004-07-14 22:39:00 EST'
+{% endif %}
+#
+{% if postgresql_recovery_target_xid %}
+recovery_target_xid = '{{postgresql_recovery_target_xid}}'
+{% else %}
+#recovery_target_xid = ''
+{% endif %}
+#
+{% if postgresql_recovery_target_inclusive %}
+recovery_target_inclusive = {{postgresql_recovery_target_inclusive}}
+{% else %}
+#recovery_target_inclusive = true
+{% endif %}
+#
+#
+# Alternatively, you can request stopping as soon as a consistent state
+# is reached, by uncommenting this option.
+#
+{% if postgresql_recovery_target %}
+recovery_target = '{{postgresql_recovery_target}}'
+{% else %}
+#recovery_target = 'immediate'
+{% endif %}
+#
+#
+# If you want to recover into a timeline other than the "main line" shown in
+# pg_control, specify the timeline number here, or write 'latest' to get
+# the latest branch for which there's a history file.
+#
+{% if postgresql_recovery_target_timeline %}
+recovery_target_timeline = '{{postgresql_recovery_target_timeline}}'
+{% else %}
+#recovery_target_timeline = 'latest'
+{% endif %}
+#
+#
+# If pause_at_recovery_target is enabled, recovery will pause when
+# the recovery target is reached. The pause state will continue until
+# pg_xlog_replay_resume() is called. This setting has no effect if
+# hot standby is not enabled, or if no recovery target is set.
+#
+{% if postgresql_pause_at_recovery_target %}
+pause_at_recovery_target = {{postgresql_pause_at_recovery_target}}
+{% else %}
+#pause_at_recovery_target = true
+{% endif %}
+#
+#---------------------------------------------------------------------------
+# STANDBY SERVER PARAMETERS
+#---------------------------------------------------------------------------
+#
+# standby_mode
+#
+# When standby_mode is enabled, the PostgreSQL server will work as a
+# standby. It will continuously wait for the additional XLOG records, using
+# restore_command and/or primary_conninfo.
+#
+{% if postgresql_standby_mode %}
+standby_mode = {{'on' if postgresql_standby_mode else 'off'}}
+{% else %}
+#standby_mode = off
+{% endif %}
+#
+# primary_conninfo
+#
+# If set, the PostgreSQL server will try to connect to the primary using this
+# connection string and receive XLOG records continuously.
+#
+{% if postgresql_primary_conninfo %}
+primary_conninfo = '{{postgresql_primary_conninfo}}'		# e.g. 'host=localhost port=5432'
+{% else %}
+#primary_conninfo = ''		# e.g. 'host=localhost port=5432'
+{% endif %}
+#
+# If set, the PostgreSQL server will use the specified replication slot when
+# connecting to the primary via streaming replication to control resource
+# removal on the upstream node. This setting has no effect if primary_conninfo
+# is not set.
+#
+{% if postgresql_primary_slot_name %}
+primary_slot_name = '{{postgresql_primary_slot_name}}'
+{% else %}
+#primary_slot_name = ''
+{% endif %}
+#
+# By default, a standby server keeps restoring XLOG records from the
+# primary indefinitely. If you want to stop the standby mode, finish recovery
+# and open the system in read/write mode, specify a path to a trigger file.
+# The server will poll the trigger file path periodically and start as a
+# primary server when it's found.
+#
+{% if postgresql_trigger_file %}
+trigger_file = '{{postgresql_trigger_file}}'
+{% else %}
+#trigger_file = ''
+{% endif %}
+#
+# By default, a standby server restores XLOG records from the primary as
+# soon as possible. If you want to explicitly delay the replay of committed
+# transactions from the master, specify a minimum apply delay. For example,
+# if you set this parameter to 5min, the standby will replay each transaction
+# commit only when the system time on the standby is at least five minutes
+# past the commit time reported by the master.
+#
+{% if postgresql_recovery_min_apply_delay %}
+recovery_min_apply_delay = {{postgresql_recovery_min_apply_delay}}
+{% else %}
+#recovery_min_apply_delay = 0
+{% endif %}
+#
+#---------------------------------------------------------------------------
+# HOT STANDBY PARAMETERS
+#---------------------------------------------------------------------------
+#
+# Hot Standby related parameters are listed in postgresql.conf
+#
+#---------------------------------------------------------------------------

--- a/templates/recovery.conf-9.4.orig
+++ b/templates/recovery.conf-9.4.orig
@@ -1,0 +1,153 @@
+# -------------------------------
+# PostgreSQL recovery config file
+# -------------------------------
+#
+# Edit this file to provide the parameters that PostgreSQL needs to
+# perform an archive recovery of a database, or to act as a replication
+# standby.
+#
+# If "recovery.conf" is present in the PostgreSQL data directory, it is
+# read on postmaster startup.  After successful recovery, it is renamed
+# to "recovery.done" to ensure that we do not accidentally re-enter
+# archive recovery or standby mode.
+#
+# This file consists of lines of the form:
+#
+#   name = value
+#
+# Comments are introduced with '#'.
+#
+# The complete list of option names and allowed values can be found
+# in the PostgreSQL documentation.
+#
+#---------------------------------------------------------------------------
+# ARCHIVE RECOVERY PARAMETERS
+#---------------------------------------------------------------------------
+#
+# restore_command
+#
+# specifies the shell command that is executed to copy log files
+# back from archival storage.  The command string may contain %f,
+# which is replaced by the name of the desired log file, and %p,
+# which is replaced by the absolute path to copy the log file to.
+#
+# This parameter is *required* for an archive recovery, but optional
+# for streaming replication.
+#
+# It is important that the command return nonzero exit status on failure.
+# The command *will* be asked for log files that are not present in the
+# archive; it must return nonzero when so asked.
+#
+# NOTE that the basename of %p will be different from %f; do not
+# expect them to be interchangeable.
+#
+#restore_command = ''		# e.g. 'cp /mnt/server/archivedir/%f %p'
+#
+#
+# archive_cleanup_command
+#
+# specifies an optional shell command to execute at every restartpoint.
+# This can be useful for cleaning up the archive of a standby server.
+#
+#archive_cleanup_command = ''
+#
+# recovery_end_command
+#
+# specifies an optional shell command to execute at completion of recovery.
+# This can be useful for cleaning up after the restore_command.
+#
+#recovery_end_command = ''
+#
+#---------------------------------------------------------------------------
+# RECOVERY TARGET PARAMETERS
+#---------------------------------------------------------------------------
+#
+# By default, recovery will rollforward to the end of the WAL log.
+# If you want to stop rollforward at a specific point, you
+# must set a recovery target.
+#
+# You may set a recovery target either by transactionId, by name,
+# or by timestamp. Recovery may either include or exclude the
+# transaction(s) with the recovery target value (ie, stop either
+# just after or just before the given target, respectively).
+#
+#
+#recovery_target_name = ''	# e.g. 'daily backup 2011-01-26'
+#
+#recovery_target_time = ''	# e.g. '2004-07-14 22:39:00 EST'
+#
+#recovery_target_xid = ''
+#
+#recovery_target_inclusive = true
+#
+#
+# Alternatively, you can request stopping as soon as a consistent state
+# is reached, by uncommenting this option.
+#
+#recovery_target = 'immediate'
+#
+#
+# If you want to recover into a timeline other than the "main line" shown in
+# pg_control, specify the timeline number here, or write 'latest' to get
+# the latest branch for which there's a history file.
+#
+#recovery_target_timeline = 'latest'
+#
+#
+# If pause_at_recovery_target is enabled, recovery will pause when
+# the recovery target is reached. The pause state will continue until
+# pg_xlog_replay_resume() is called. This setting has no effect if
+# hot standby is not enabled, or if no recovery target is set.
+#
+#pause_at_recovery_target = true
+#
+#---------------------------------------------------------------------------
+# STANDBY SERVER PARAMETERS
+#---------------------------------------------------------------------------
+#
+# standby_mode
+#
+# When standby_mode is enabled, the PostgreSQL server will work as a
+# standby. It will continuously wait for the additional XLOG records, using
+# restore_command and/or primary_conninfo.
+#
+#standby_mode = off
+#
+# primary_conninfo
+#
+# If set, the PostgreSQL server will try to connect to the primary using this
+# connection string and receive XLOG records continuously.
+#
+#primary_conninfo = ''		# e.g. 'host=localhost port=5432'
+#
+# If set, the PostgreSQL server will use the specified replication slot when
+# connecting to the primary via streaming replication to control resource
+# removal on the upstream node. This setting has no effect if primary_conninfo
+# is not set.
+#
+#primary_slot_name = ''
+#
+# By default, a standby server keeps restoring XLOG records from the
+# primary indefinitely. If you want to stop the standby mode, finish recovery
+# and open the system in read/write mode, specify a path to a trigger file.
+# The server will poll the trigger file path periodically and start as a
+# primary server when it's found.
+#
+#trigger_file = ''
+#
+# By default, a standby server restores XLOG records from the primary as
+# soon as possible. If you want to explicitly delay the replay of committed
+# transactions from the master, specify a minimum apply delay. For example,
+# if you set this parameter to 5min, the standby will replay each transaction
+# commit only when the system time on the standby is at least five minutes
+# past the commit time reported by the master.
+#
+#recovery_min_apply_delay = 0
+#
+#---------------------------------------------------------------------------
+# HOT STANDBY PARAMETERS
+#---------------------------------------------------------------------------
+#
+# Hot Standby related parameters are listed in postgresql.conf
+#
+#---------------------------------------------------------------------------

--- a/templates/recovery.conf-9.5.j2
+++ b/templates/recovery.conf-9.5.j2
@@ -1,0 +1,215 @@
+# -------------------------------
+# PostgreSQL recovery config file
+# -------------------------------
+#
+# Edit this file to provide the parameters that PostgreSQL needs to
+# perform an archive recovery of a database, or to act as a replication
+# standby.
+#
+# If "recovery.conf" is present in the PostgreSQL data directory, it is
+# read on postmaster startup.  After successful recovery, it is renamed
+# to "recovery.done" to ensure that we do not accidentally re-enter
+# archive recovery or standby mode.
+#
+# This file consists of lines of the form:
+#
+#   name = value
+#
+# Comments are introduced with '#'.
+#
+# The complete list of option names and allowed values can be found
+# in the PostgreSQL documentation.
+#
+#---------------------------------------------------------------------------
+# ARCHIVE RECOVERY PARAMETERS
+#---------------------------------------------------------------------------
+#
+# restore_command
+#
+# specifies the shell command that is executed to copy log files
+# back from archival storage.  The command string may contain %f,
+# which is replaced by the name of the desired log file, and %p,
+# which is replaced by the absolute path to copy the log file to.
+#
+# This parameter is *required* for an archive recovery, but optional
+# for streaming replication.
+#
+# It is important that the command return nonzero exit status on failure.
+# The command *will* be asked for log files that are not present in the
+# archive; it must return nonzero when so asked.
+#
+# NOTE that the basename of %p will be different from %f; do not
+# expect them to be interchangeable.
+#
+{% if postgresql_restore_command %}
+restore_command = '{{postgresql_restore_command}}'		# e.g. 'cp /mnt/server/archivedir/%f %p'
+{% else %}
+#restore_command = ''		# e.g. 'cp /mnt/server/archivedir/%f %p'
+{% endif %}
+#
+#
+# archive_cleanup_command
+#
+# specifies an optional shell command to execute at every restartpoint.
+# This can be useful for cleaning up the archive of a standby server.
+#
+{% if postgresql_archive_cleanup_command %}
+archive_cleanup_command = '{{postgresql_archive_cleanup_command}}'
+{% else %}
+#archive_cleanup_command = ''
+{% endif %}
+#
+# recovery_end_command
+#
+# specifies an optional shell command to execute at completion of recovery.
+# This can be useful for cleaning up after the restore_command.
+#
+{% if postgresql_recovery_end_command %}
+recovery_end_command = '{{postgresql_recovery_end_command}}'
+{% else %}
+#recovery_end_command = ''
+{% endif %}
+#
+#---------------------------------------------------------------------------
+# RECOVERY TARGET PARAMETERS
+#---------------------------------------------------------------------------
+#
+# By default, recovery will rollforward to the end of the WAL log.
+# If you want to stop rollforward at a specific point, you
+# must set a recovery target.
+#
+# You may set a recovery target either by transactionId, by name,
+# or by timestamp. Recovery may either include or exclude the
+# transaction(s) with the recovery target value (ie, stop either
+# just after or just before the given target, respectively).
+#
+#
+{% if postgresql_recovery_target_name %}
+recovery_target_name = '{{postgresql_recovery_target_name}}'	# e.g. 'daily backup 2011-01-26'
+{% else %}
+#recovery_target_name = ''	# e.g. 'daily backup 2011-01-26'
+{% endif %}
+#
+{% if postgresql_recovery_target_time %}
+recovery_target_time = '{{postgresql_recovery_target_time}}'	# e.g. '2004-07-14 22:39:00 EST'
+{% else %}
+#recovery_target_time = ''	# e.g. '2004-07-14 22:39:00 EST'
+{% endif %}
+#
+{% if postgresql_recovery_target_xid %}
+recovery_target_xid = '{{postgresql_recovery_target_xid}}'
+{% else %}
+#recovery_target_xid = ''
+{% endif %}
+#
+{% if postgresql_recovery_target_inclusive %}
+recovery_target_inclusive = {{postgresql_recovery_target_inclusive}}
+{% else %}
+#recovery_target_inclusive = true
+{% endif %}
+#
+#
+# Alternatively, you can request stopping as soon as a consistent state
+# is reached, by uncommenting this option.
+#
+{% if postgresql_recovery_target %}
+recovery_target = '{{postgresql_recovery_target}}'
+{% else %}
+#recovery_target = 'immediate'
+{% endif %}
+#
+#
+# If you want to recover into a timeline other than the "main line" shown in
+# pg_control, specify the timeline number here, or write 'latest' to get
+# the latest branch for which there's a history file.
+#
+{% if postgresql_recovery_target_timeline %}
+recovery_target_timeline = '{{postgresql_recovery_target_timeline}}'
+{% else %}
+#recovery_target_timeline = 'latest'
+{% endif %}
+#
+#
+# If recovery_target_action = 'pause', recovery will pause when the
+# recovery target is reached. The pause state will continue until
+# pg_xlog_replay_resume() is called. This setting has no effect if
+# no recovery target is set. If hot_standby is not enabled then the
+# server will shutdown instead, though you may request this in
+# any case by specifying 'shutdown'.
+#
+{% if postgresql_recovery_target_action %}
+recovery_target_actio = {{postgresql_recovery_target_action}}
+{% else %}
+#recovery_target_action = 'pause'
+{% endif %}
+#
+#---------------------------------------------------------------------------
+# STANDBY SERVER PARAMETERS
+#---------------------------------------------------------------------------
+#
+# standby_mode
+#
+# When standby_mode is enabled, the PostgreSQL server will work as a
+# standby. It will continuously wait for the additional XLOG records, using
+# restore_command and/or primary_conninfo.
+#
+{% if postgresql_standby_mode %}
+standby_mode = {{'on' if postgresql_standby_mode else 'off'}}
+{% else %}
+#standby_mode = off
+{% endif %}
+#
+# primary_conninfo
+#
+# If set, the PostgreSQL server will try to connect to the primary using this
+# connection string and receive XLOG records continuously.
+#
+{% if postgresql_primary_conninfo %}
+primary_conninfo = '{{postgresql_primary_conninfo}}'		# e.g. 'host=localhost port=5432'
+{% else %}
+#primary_conninfo = ''		# e.g. 'host=localhost port=5432'
+{% endif %}
+#
+# If set, the PostgreSQL server will use the specified replication slot when
+# connecting to the primary via streaming replication to control resource
+# removal on the upstream node. This setting has no effect if primary_conninfo
+# is not set.
+#
+{% if postgresql_primary_slot_name %}
+primary_slot_name = '{{postgresql_primary_slot_name}}'
+{% else %}
+#primary_slot_name = ''
+{% endif %}
+#
+# By default, a standby server keeps restoring XLOG records from the
+# primary indefinitely. If you want to stop the standby mode, finish recovery
+# and open the system in read/write mode, specify a path to a trigger file.
+# The server will poll the trigger file path periodically and start as a
+# primary server when it's found.
+#
+{% if postgresql_trigger_file %}
+trigger_file = '{{postgresql_trigger_file}}'
+{% else %}
+#trigger_file = ''
+{% endif %}
+#
+# By default, a standby server restores XLOG records from the primary as
+# soon as possible. If you want to explicitly delay the replay of committed
+# transactions from the master, specify a minimum apply delay. For example,
+# if you set this parameter to 5min, the standby will replay each transaction
+# commit only when the system time on the standby is at least five minutes
+# past the commit time reported by the master.
+#
+{% if postgresql_recovery_min_apply_delay %}
+recovery_min_apply_delay = {{postgresql_recovery_min_apply_delay}}
+{% else %}
+#recovery_min_apply_delay = 0
+{% endif %}
+#
+#---------------------------------------------------------------------------
+# HOT STANDBY PARAMETERS
+#---------------------------------------------------------------------------
+#
+# Hot Standby related parameters are listed in postgresql.conf
+#
+#---------------------------------------------------------------------------

--- a/templates/recovery.conf-9.5.orig
+++ b/templates/recovery.conf-9.5.orig
@@ -1,0 +1,155 @@
+# -------------------------------
+# PostgreSQL recovery config file
+# -------------------------------
+#
+# Edit this file to provide the parameters that PostgreSQL needs to
+# perform an archive recovery of a database, or to act as a replication
+# standby.
+#
+# If "recovery.conf" is present in the PostgreSQL data directory, it is
+# read on postmaster startup.  After successful recovery, it is renamed
+# to "recovery.done" to ensure that we do not accidentally re-enter
+# archive recovery or standby mode.
+#
+# This file consists of lines of the form:
+#
+#   name = value
+#
+# Comments are introduced with '#'.
+#
+# The complete list of option names and allowed values can be found
+# in the PostgreSQL documentation.
+#
+#---------------------------------------------------------------------------
+# ARCHIVE RECOVERY PARAMETERS
+#---------------------------------------------------------------------------
+#
+# restore_command
+#
+# specifies the shell command that is executed to copy log files
+# back from archival storage.  The command string may contain %f,
+# which is replaced by the name of the desired log file, and %p,
+# which is replaced by the absolute path to copy the log file to.
+#
+# This parameter is *required* for an archive recovery, but optional
+# for streaming replication.
+#
+# It is important that the command return nonzero exit status on failure.
+# The command *will* be asked for log files that are not present in the
+# archive; it must return nonzero when so asked.
+#
+# NOTE that the basename of %p will be different from %f; do not
+# expect them to be interchangeable.
+#
+#restore_command = ''		# e.g. 'cp /mnt/server/archivedir/%f %p'
+#
+#
+# archive_cleanup_command
+#
+# specifies an optional shell command to execute at every restartpoint.
+# This can be useful for cleaning up the archive of a standby server.
+#
+#archive_cleanup_command = ''
+#
+# recovery_end_command
+#
+# specifies an optional shell command to execute at completion of recovery.
+# This can be useful for cleaning up after the restore_command.
+#
+#recovery_end_command = ''
+#
+#---------------------------------------------------------------------------
+# RECOVERY TARGET PARAMETERS
+#---------------------------------------------------------------------------
+#
+# By default, recovery will rollforward to the end of the WAL log.
+# If you want to stop rollforward at a specific point, you
+# must set a recovery target.
+#
+# You may set a recovery target either by transactionId, by name,
+# or by timestamp. Recovery may either include or exclude the
+# transaction(s) with the recovery target value (ie, stop either
+# just after or just before the given target, respectively).
+#
+#
+#recovery_target_name = ''	# e.g. 'daily backup 2011-01-26'
+#
+#recovery_target_time = ''	# e.g. '2004-07-14 22:39:00 EST'
+#
+#recovery_target_xid = ''
+#
+#recovery_target_inclusive = true
+#
+#
+# Alternatively, you can request stopping as soon as a consistent state
+# is reached, by uncommenting this option.
+#
+#recovery_target = 'immediate'
+#
+#
+# If you want to recover into a timeline other than the "main line" shown in
+# pg_control, specify the timeline number here, or write 'latest' to get
+# the latest branch for which there's a history file.
+#
+#recovery_target_timeline = 'latest'
+#
+#
+# If recovery_target_action = 'pause', recovery will pause when the
+# recovery target is reached. The pause state will continue until
+# pg_xlog_replay_resume() is called. This setting has no effect if
+# no recovery target is set. If hot_standby is not enabled then the
+# server will shutdown instead, though you may request this in
+# any case by specifying 'shutdown'.
+#
+#recovery_target_action = 'pause'
+#
+#---------------------------------------------------------------------------
+# STANDBY SERVER PARAMETERS
+#---------------------------------------------------------------------------
+#
+# standby_mode
+#
+# When standby_mode is enabled, the PostgreSQL server will work as a
+# standby. It will continuously wait for the additional XLOG records, using
+# restore_command and/or primary_conninfo.
+#
+#standby_mode = off
+#
+# primary_conninfo
+#
+# If set, the PostgreSQL server will try to connect to the primary using this
+# connection string and receive XLOG records continuously.
+#
+#primary_conninfo = ''		# e.g. 'host=localhost port=5432'
+#
+# If set, the PostgreSQL server will use the specified replication slot when
+# connecting to the primary via streaming replication to control resource
+# removal on the upstream node. This setting has no effect if primary_conninfo
+# is not set.
+#
+#primary_slot_name = ''
+#
+# By default, a standby server keeps restoring XLOG records from the
+# primary indefinitely. If you want to stop the standby mode, finish recovery
+# and open the system in read/write mode, specify a path to a trigger file.
+# The server will poll the trigger file path periodically and start as a
+# primary server when it's found.
+#
+#trigger_file = ''
+#
+# By default, a standby server restores XLOG records from the primary as
+# soon as possible. If you want to explicitly delay the replay of committed
+# transactions from the master, specify a minimum apply delay. For example,
+# if you set this parameter to 5min, the standby will replay each transaction
+# commit only when the system time on the standby is at least five minutes
+# past the commit time reported by the master.
+#
+#recovery_min_apply_delay = 0
+#
+#---------------------------------------------------------------------------
+# HOT STANDBY PARAMETERS
+#---------------------------------------------------------------------------
+#
+# Hot Standby related parameters are listed in postgresql.conf
+#
+#---------------------------------------------------------------------------


### PR DESCRIPTION
There is a difference in "recovery.conf parameter absent" and "recovery.conf parameter present and set to default", so all recovery.conf parameters are left empty by default (see src/backend/access/transam/xlog.c for details).
